### PR TITLE
#10: 勝敗表のセルの表示を変更

### DIFF
--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -27,6 +27,13 @@
         td.advantage {
             background-color: #CCFFFF /* 薄い青 */
         }
+        .standing-winrate {
+            font-weight: bold;
+            font-size: 1.2em
+        }
+        .standing-winlose {
+            font-size: 0.8em
+        }
         .table-height-scrollable tr:first-child th:first-child {
             z-index: 1;
         }
@@ -113,9 +120,11 @@
                         th:with="incrementedValue=${colCount.index},
                                 isSameDeck=${rowCount.index == colCount.index},
                                 isExistResult=${!isSameDeck && (item.winrate != -1.0)},
-                                displayText=${isExistResult ? (item.winCount + '-' + item.lossCount) : ''}"
+                                displayWinrate=${'<div class=&quot;standing-winrate&quot;>' + #numbers.formatDecimal(item.winrate * 100, 1, 2) + '%' + '</div>'},
+                                displayWinLose=${'<div class=&quot;standing-winlose&quot;>' + item.winCount + '-' + item.lossCount + '</div>'},
+                                displayTextIfExists=${displayWinrate + displayWinLose}"
                         th:classappend="${isSameDeck ? 'same' : (item.winrate > 0.5 ? 'advantage' : '')}"
-                        th:text="${displayText}">
+                        th:utext="${isExistResult ? displayTextIfExists : ''}">
                     </td>
                 </tr>
                 </tbody>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -110,9 +110,12 @@
                     style="font-size: 90%">
                     <td th:text="${deckList[rowCount.index].name}" class="sticky"></td>
                     <td th:each="item, colCount : ${row}"
-                        th:with="incrementedValue=${colCount.index}"
-                        th:classappend="${rowCount.index == colCount.index ? 'same' : item.winrate > 0.5 ? 'advantage' : ''}"
-                        th:text="${rowCount.index == colCount.index ? '' : item.winrate == -1.0 ? '-' : item.winCount + '-' + item.lossCount}">
+                        th:with="incrementedValue=${colCount.index},
+                                isSameDeck=${rowCount.index == colCount.index},
+                                isExistResult=${!isSameDeck && (item.winrate != -1.0)},
+                                displayText=${isExistResult ? (item.winCount + '-' + item.lossCount) : ''}"
+                        th:classappend="${isSameDeck ? 'same' : (item.winrate > 0.5 ? 'advantage' : '')}"
+                        th:text="${displayText}">
                     </td>
                 </tr>
                 </tbody>

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -7,7 +7,7 @@
 <head>
     <title>Top Page</title>
     <style>
-        @media (max-width:700px) {
+        @media (max-width:1000px) {
             /** スマホなどで閲覧する際、テーブルをスクロール可能にする **/
             .table-large {
                 width: 700px;
@@ -28,8 +28,7 @@
             background-color: #CCFFFF /* 薄い青 */
         }
         .standing-winrate {
-            font-weight: bold;
-            font-size: 1.2em
+            font-weight: bold
         }
         .standing-winlose {
             font-size: 0.8em
@@ -57,6 +56,10 @@
             width: 100%;
             height: 100%;
             z-index: -1;
+        }
+        .table-first-row {
+            height: 6em;
+            line-height: 150%
         }
     </style>
 </head>
@@ -103,9 +106,9 @@
         </p>
 
         <!-- 勝敗表本体 -->
-        <div class="table-responsive table-height-scrollable">
+        <div class="table-height-scrollable">
             <table class="table table-large table-hover" style="table-layout: fixed">
-                <thead class="table-light">
+                <thead class="table-light" style="font-size:80%">
                 <tr>
                     <th class="sticky"></th>
                     <th class="sticky" th:each="deck : ${deckList}" th:text="${deck.name}" style="font-size: 90%"></th>
@@ -115,7 +118,7 @@
                 <tr th:each="row, rowCount : ${standings}"
                     th:with="incrementedValue=${rowCount.index}"
                     style="font-size: 90%">
-                    <td th:text="${deckList[rowCount.index].name}" class="sticky"></td>
+                    <td th:text="${deckList[rowCount.index].name}" class="sticky table-first-row"></td>
                     <td th:each="item, colCount : ${row}"
                         th:with="incrementedValue=${colCount.index},
                                 isSameDeck=${rowCount.index == colCount.index},


### PR DESCRIPTION
```
<winrate: \d{2}.d{2}>
<wins>-<losses>
```

というようにした。

![image](https://github.com/user-attachments/assets/d9274573-6898-4682-abf8-d31fa21fa703)
